### PR TITLE
do not call allowCreate from allowUpdate

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -87,20 +87,7 @@ function applyPermissions(path, { resource, acls }) {
 		 * @return {*|boolean}
 		 */
 		allowCreate(user, query, context) {
-			let id = this.getId();
-			if (!Array.isArray(id)) {
-				if (!id) {
-					id = [];
-				} else {
-					id = [id];
-				}
-			}
-			id = [...path, ...id];
-			const allowed_topics = findTopicsForUser(acls, user, context?.session?.sessionId, true);
-			if (mqttPermissionCheck(id, allowed_topics)) {
-				return true;
-			}
-			return super.allowCreate(user);
+			return this._allowUpdateAndCreate(user, query, context) || super.allowCreate(user);
 		}
 
 		/**
@@ -111,6 +98,18 @@ function applyPermissions(path, { resource, acls }) {
 		 * @return {*|boolean}
 		 */
 		allowUpdate(user, query, context) {
+			return this._allowUpdateAndCreate(user, query, context) || super.allowUpdate(user);
+		}
+
+		/**
+		 * Check if the user is allowed to publish and update the topic (resource)
+		 * @private
+		 * @param user
+		 * @param query
+		 * @param context
+		 * @return {boolean}
+		 */
+		_allowUpdateAndCreate(user, query, context) {
 			let id = this.getId();
 			if (!Array.isArray(id)) {
 				if (!id) {
@@ -121,10 +120,7 @@ function applyPermissions(path, { resource, acls }) {
 			}
 			id = [...path, ...id];
 			const allowed_topics = findTopicsForUser(acls, user, context?.session?.sessionId, true);
-			if (mqttPermissionCheck(id, allowed_topics)) {
-				return true;
-			}
-			return super.allowUpdate(user);
+			return mqttPermissionCheck(id, allowed_topics);
 		}
 	}
 }

--- a/extension.js
+++ b/extension.js
@@ -23,7 +23,7 @@ export function start({ ensureTable, database, monitoring }) {
 				// If there is an existing exported resource, we will use that, trying for most specific first.
 				// This allows for an exported resource to be mapped to a sub-topic, which can be used to define
 				// separate sub-topics to have different table backings.
-				resource_path = path.slice(0,i).join('/');
+				resource_path = path.slice(0, i).join('/');
 				if (resource_path === '$SYS') {
 					// we specifically look for the special $SYS topic, which is used for monitoring, and setup monitoring
 					// on-demand if the user has defined an ACL for it
@@ -48,12 +48,12 @@ export function start({ ensureTable, database, monitoring }) {
 			if (!resource_entry) resources_to_permission.set(resource_path, resource_entry = { resource: resource_to_permission, acls: [] });
 			resource_entry.acls.push(acl);
 		}
-		for (let [ resource_path, resource_entry ] of resources_to_permission) {
+		for (let [resource_path, resource_entry] of resources_to_permission) {
 			// now apply the set of ACLs to the resource, extending the resource to define access
 			const new_resource_class = applyPermissions(resource_path.split('/'), resource_entry);
 			// And export the new resource class with permissions applied (potentially re-exporting user resource with
 			// permissions applied)
-			resources.set(resource_path, new_resource_class );
+			resources.set(resource_path, new_resource_class);
 		}
 	}
 }
@@ -69,7 +69,7 @@ function applyPermissions(path, { resource, acls }) {
 		allowRead(user, query, context) {
 			const topic = context?.topic;
 			let id = topic?.split('/');
-			if(!id) {
+			if (!id) {
 				id = [];
 			}
 			const allowed_topics = findTopicsForUser(acls, user, context?.session?.sessionId, false);
@@ -111,7 +111,20 @@ function applyPermissions(path, { resource, acls }) {
 		 * @return {*|boolean}
 		 */
 		allowUpdate(user, query, context) {
-			return this.allowCreate(user, query, context);
+			let id = this.getId();
+			if (!Array.isArray(id)) {
+				if (!id) {
+					id = [];
+				} else {
+					id = [id];
+				}
+			}
+			id = [...path, ...id];
+			const allowed_topics = findTopicsForUser(acls, user, context?.session?.sessionId, true);
+			if (mqttPermissionCheck(id, allowed_topics)) {
+				return true;
+			}
+			return super.allowUpdate(user);
 		}
 	}
 }


### PR DESCRIPTION
When `allowUpdate` is called on the resource, it calls `this.allowCreate`. But, for some reason, `super.allowCreate`(called in  `allowCreate` when no permissions are found) ends up calling `allowUpdate`, and, which becomes an infinite loop.

In `4.3`:  `allowUpdate` is not being called (atleast for the ibm-events use case), so we never run into that stack overflow issue above

In `4.4` : `allowUpdate` is called, so we get a stack overflow.

I'll have to do some more digging to see why `super.allowCreate` ends up calling `allowUpdate` and why 4.4 calls update in core, but I just wanted to get this fix out first.

The current fix just undoes this previous commit https://github.com/HarperDB/acl-connect/commit/1731bd40d1f5c2e3aee90670d70212678dae9fc7 